### PR TITLE
Global clean up

### DIFF
--- a/include/my_ncurses.h
+++ b/include/my_ncurses.h
@@ -46,4 +46,21 @@ void my_addstr(my_window *window, const char *str);
 #define my_mvaddstr(window, y, x, str) (my_move(window, y, x), \
 my_addstr(window, str))
 
+
+#define COLOR 0
+#define BACKGROUND_COLOR 10
+#define BRIGHT_MODIFIER 60
+
+#define BLACK 30
+#define RED 31
+#define GREEN 32
+#define YELLOW 33
+#define BLUE 34
+#define MAGENTA 53
+#define CYAN 36
+#define WHITE 37
+
+#define my_attron(attr, value) (printf("\x1B[%dm", attr + value))
+#define my_attrreset() (printf("\x1B[0m"))
+
 void my_clrtoeol(void);

--- a/src/builtin/builtin_manager.c
+++ b/src/builtin/builtin_manager.c
@@ -17,10 +17,11 @@
 int run_builtin(const builtin *cmd, char **a, redirection *inout[2], env_t *env)
 {
     int ret = 0;
-    int saved_fd[2];
+    int saved_fd[3];
 
     saved_fd[0] = dup(0);
     saved_fd[1] = dup(1);
+    saved_fd[2] = dup(2);
     if (saved_fd[0] < 0 || saved_fd[1] < 0) {
         perror("mysh");
         return (-1);
@@ -29,8 +30,10 @@ int run_builtin(const builtin *cmd, char **a, redirection *inout[2], env_t *env)
         ret = cmd->run(a, env);
     dup2(saved_fd[0], 0);
     dup2(saved_fd[1], 1);
+    dup2(saved_fd[2], 2);
     close(saved_fd[0]);
     close(saved_fd[1]);
+    close(saved_fd[2]);
     if (handle_parent_inout(inout, env, true))
         ret = 0;
     return (ret);

--- a/src/key_bindings/basic_typing_functions.c
+++ b/src/key_bindings/basic_typing_functions.c
@@ -68,7 +68,7 @@ int newline_command(int key, buffer_t *buffer, env_t *env)
     ret = eval_raw_cmd(buffer->buffer, env);
     buffer->buffer[0] = '\0';
     buffer->pos = 0;
-    if (env->window)
+    if (env->window && ret >= 0)
         prompt_prepare(buffer, env);
     return (ret);
 }

--- a/src/redirections/pty_pipe.c
+++ b/src/redirections/pty_pipe.c
@@ -6,15 +6,16 @@
 */
 
 #include "redirections.h"
+#include "my_ncurses.h"
 #include <malloc.h>
 #include <unistd.h>
 #include <fcntl.h>
 #include <stdio.h>
 #include <errno.h>
 #include <stddef.h>
-#include <ncurses.h>
 #include <termios.h>
 #include <sys/ioctl.h>
+#include <string.h>
 #define _XOPEN_SOURCE 600
 #define __USE_XOPEN_EXTENDED
 #include <stdlib.h>
@@ -88,7 +89,14 @@ void pty_get_output(redirection *pty, env_t *env)
     close(pty->fd);
     while (getline(&line, &size, file) > 0)
         my_addstr(env->window, line);
-    if (line)
+    if (line) {
+        if (!strchr(line, '\n')) {
+            my_attron(BACKGROUND_COLOR, WHITE);
+            my_attron(COLOR, BLACK);
+            my_addstr(env->window, "%\n");
+            my_attrreset();
+        }
         free(line);
+    }
     fclose(file);
 }

--- a/src/redirections/pty_pipe.c
+++ b/src/redirections/pty_pipe.c
@@ -90,7 +90,7 @@ void pty_get_output(redirection *pty, env_t *env)
     while (getline(&line, &size, file) > 0)
         my_addstr(env->window, line);
     if (line) {
-        if (!strchr(line, '\n')) {
+        if (line[0] && !strchr(line, '\n')) {
             my_attron(BACKGROUND_COLOR, WHITE);
             my_attron(COLOR, BLACK);
             my_addstr(env->window, "%\n");


### PR DESCRIPTION
 - Fixing a bug that prevented builtins to return.
 - Adding a % and a forced \n if a program's last line was lacking a \n (like zsh).